### PR TITLE
Add terraform bucket and state lock table.

### DIFF
--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -1,6 +1,9 @@
 name: Run Terraform Checks
 on:
   pull_request:
+permissions:
+  id-token: write
+  contents: write
 jobs:
   terraform-check:
     runs-on: ubuntu-latest

--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Configure AWS credentials for S3 state file access
         uses: aws-actions/configure-aws-credentials@v1-node16
         with:
-          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/MgmtDPTerraformGitHubRepositoriesRole
+          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/MgmtDPBootstrapTerraformGitHubRepositoriesRole
           aws-region: eu-west-2
           role-session-name: TerraformRole
       - name: Terraform Format

--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -15,5 +15,6 @@ jobs:
       - name: Terraform Format
         id: fmt
         run: |
+          terraform init
           terraform fmt -check --recursive
           terraform validate

--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -12,6 +12,12 @@ jobs:
         with:
           message: ":warning: Secrets found in repository dp-terraform-backend"
           slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Configure AWS credentials for S3 state file access
+        uses: aws-actions/configure-aws-credentials@v1-node16
+        with:
+          role-to-assume: arn:aws:iam::${{ secrets.MANAGEMENT_ACCOUNT }}:role/MgmtDPTerraformGitHubRepositoriesRole
+          aws-region: eu-west-2
+          role-session-name: TerraformRole
       - name: Terraform Format
         id: fmt
         run: |

--- a/.github/workflows/terraform_check.yml
+++ b/.github/workflows/terraform_check.yml
@@ -1,0 +1,19 @@
+name: Run Terraform Checks
+on:
+  pull_request:
+jobs:
+  terraform-check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: nationalarchives/tdr-github-actions/.github/actions/run-git-secrets@main
+      - uses: nationalarchives/tdr-github-actions/.github/actions/slack-send@main
+        if: failure()
+        with:
+          message: ":warning: Secrets found in repository dp-terraform-backend"
+          slack-url: ${{ secrets.SLACK_WEBHOOK }}
+      - name: Terraform Format
+        id: fmt
+        run: |
+          terraform fmt -check --recursive
+          terraform validate

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.terraform

--- a/.terraform.lock.hcl
+++ b/.terraform.lock.hcl
@@ -1,0 +1,24 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version = "4.64.0"
+  hashes = [
+    "h1:EX5GYesrJ270/uCa3oklgIT4NdkZj1TeEDmYmrelZp4=",
+    "zh:092614f767995140cf444cad1a97fb569885db16cb1c1dc9ee56e801232bac29",
+    "zh:142e262fbb162c8a86493cfab4aadaf96a8572f1a3a6be444d465a4aee377dba",
+    "zh:1c58c8cb9934dc98a2dd9dc48a8a3d94a14c2c3f2bc0136410a9344938d4ecfb",
+    "zh:36efdf30cd52b92668cf6f912538c6e176b1a140a00e63ee0f753b85878c8b53",
+    "zh:4c631e367fd69692b57f85564de561733380e9674e146d3a7725b781ec5db944",
+    "zh:57ace91cb022ec944ad3af9272b78f48e7f71e9d1bf113ca56c6ce8deb4341fe",
+    "zh:7fc9581b530ebf28fda80c62c20c6fbbb936a878c24872349eb107b7f198e64c",
+    "zh:8280cd8f04c31af83f3e74f07704b258fbaa8bf1d70679d5ea2f0cbda2571de2",
+    "zh:8e6217a9443b651d4349d75bdc37af9298970d854bf515d8c305919b193e4a38",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9c62bc4a9034a6caf15b8863da6f5a621b947d5fca161b4bd2f2e8e78eec8e3b",
+    "zh:9d0a45cd4a031d19ee14c0a15f25df6359dcd342ccf4e2ee4751b3ee496edb57",
+    "zh:ab47f4e300c46dc1757e2b8d8d749f34f044f219479106a00bf40572091a8999",
+    "zh:b55119290497dda96ab9ba3dca00d648808dc99d18960ad8aa875775bfaf95db",
+    "zh:df513941e6979f557edcac28d84bd91af9786104b0deba45b3b259a5ad215897",
+  ]
+}

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # DP Terraform Backend
+
+This repository will store resources that need to be created before we can create other resources with terraform.
+
+* S3 state bucket
+* Dynamo state lock table
+* Terraform roles and permissions for running in GitHub actions. 
+
+The state bucket and lock table have been created manually for this repository.
+
+## Running dp-terraform-backend
+There is a GitHub workflow which checks that the terraform is valid and formatted correctly before a pull request is merged but there is no deploy job.
+The deployment will need to be done manually by someone with appropriate permissions. We may create a role in here so we can deploy it from GitHub actions in the future.

--- a/root.tf
+++ b/root.tf
@@ -2,15 +2,31 @@ locals {
   terraform_state_bucket_name = "mgmt-dp-terraform-state"
 }
 module "terraform_s3_bucket" {
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3"
+  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3?ref=add-s3-module"
   bucket_name           = local.terraform_state_bucket_name
   bucket_policy         = templatefile("${path.module}/templates/s3/s3_secure_transport.json.tpl", { bucket_name = local.terraform_state_bucket_name })
   logging_bucket_policy = templatefile("${path.module}/templates/s3/s3_secure_transport_logging.json.tpl", { bucket_name = "${local.terraform_state_bucket_name}-logs" })
 }
 
 module "terraform_dynamo" {
-  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo"
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo?ref=add-s3-module"
   hash_key      = "LockID"
   hash_key_type = "S"
   table_name    = "mgmt-dp-terraform-state-lock"
+}
+
+module "terraform_github_repository_iam" {
+  source             = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dp-terraform-github-repositories" })
+  common_tags        = {}
+  name               = "MgmtDPTerraformGitHubRepositoriesRole"
+  policy_attachments = {
+    state_access_policy = module.terraform_github_repository_policy.policy_arn
+  }
+}
+
+module "terraform_github_repository_policy" {
+  source        = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_policy"
+  name          = "MgmtDPTerraformGitHubRepositoriesPolicy"
+  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name })
 }

--- a/root.tf
+++ b/root.tf
@@ -1,0 +1,16 @@
+locals {
+  terraform_state_bucket_name = "mgmt-dp-terraform-state"
+}
+module "terraform_s3_bucket" {
+  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3"
+  bucket_name           = local.terraform_state_bucket_name
+  bucket_policy         = templatefile("${path.module}/templates/s3/s3_secure_transport.json.tpl", { bucket_name = local.terraform_state_bucket_name })
+  logging_bucket_policy = templatefile("${path.module}/templates/s3/s3_secure_transport_logging.json.tpl", { bucket_name = "${local.terraform_state_bucket_name}-logs" })
+}
+
+module "terraform_dynamo" {
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo"
+  hash_key      = "LockID"
+  hash_key_type = "S"
+  table_name    = "mgmt-dp-terraform-state-lock"
+}

--- a/root.tf
+++ b/root.tf
@@ -22,6 +22,7 @@ module "terraform_github_repository_iam" {
   name               = "MgmtDPTerraformGitHubRepositoriesRole"
   policy_attachments = {
     state_access_policy = module.terraform_github_repository_policy.policy_arn
+    ssm_policy          = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
   }
 }
 

--- a/root.tf
+++ b/root.tf
@@ -22,7 +22,7 @@ module "terraform_github_repository_iam" {
   name               = "MgmtDPTerraformGitHubRepositoriesRole"
   policy_attachments = {
     state_access_policy = module.terraform_github_repository_policy.policy_arn
-    ssm_policy          = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+    ssm_policy          = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
   }
 }
 

--- a/root.tf
+++ b/root.tf
@@ -2,14 +2,14 @@ locals {
   terraform_state_bucket_name = "mgmt-dp-terraform-state"
 }
 module "terraform_s3_bucket" {
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3"
+  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3?ref=add-s3-module"
   bucket_name           = local.terraform_state_bucket_name
   bucket_policy         = templatefile("${path.module}/templates/s3/s3_secure_transport.json.tpl", { bucket_name = local.terraform_state_bucket_name })
   logging_bucket_policy = templatefile("${path.module}/templates/s3/s3_secure_transport_logging.json.tpl", { bucket_name = "${local.terraform_state_bucket_name}-logs" })
 }
 
 module "terraform_dynamo" {
-  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo"
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo?ref=add-s3-module"
   hash_key      = "LockID"
   hash_key_type = "S"
   table_name    = "mgmt-dp-terraform-state-lock"
@@ -29,4 +29,12 @@ module "terraform_github_repository_policy" {
   source        = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_policy"
   name          = "MgmtDPTerraformGitHubRepositoriesPolicy"
   policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name })
+}
+
+module "github_oidc_provider" {
+  source      = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//identity_provider"
+  audience    = "sts.amazonaws.com"
+  thumbprint  = "6938fd4d98bab03faadb97b34396831e3780aea1"
+  url         = "https://token.actions.githubusercontent.com"
+  common_tags = {}
 }

--- a/root.tf
+++ b/root.tf
@@ -17,7 +17,7 @@ module "terraform_dynamo" {
 
 module "terraform_github_repository_iam" {
   source             = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_role"
-  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dp-terraform-github-repositories:*" })
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dp-*" })
   common_tags        = {}
   name               = "MgmtDPTerraformGitHubRepositoriesRole"
   policy_attachments = {

--- a/root.tf
+++ b/root.tf
@@ -2,14 +2,14 @@ locals {
   terraform_state_bucket_name = "mgmt-dp-terraform-state"
 }
 module "terraform_s3_bucket" {
-  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3?ref=add-s3-module"
+  source                = "git::https://github.com/nationalarchives/da-terraform-modules.git//s3"
   bucket_name           = local.terraform_state_bucket_name
   bucket_policy         = templatefile("${path.module}/templates/s3/s3_secure_transport.json.tpl", { bucket_name = local.terraform_state_bucket_name })
   logging_bucket_policy = templatefile("${path.module}/templates/s3/s3_secure_transport_logging.json.tpl", { bucket_name = "${local.terraform_state_bucket_name}-logs" })
 }
 
 module "terraform_dynamo" {
-  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo?ref=add-s3-module"
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo"
   hash_key      = "LockID"
   hash_key_type = "S"
   table_name    = "mgmt-dp-terraform-state-lock"

--- a/root.tf
+++ b/root.tf
@@ -17,7 +17,7 @@ module "terraform_dynamo" {
 
 module "terraform_github_repository_iam" {
   source             = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_role"
-  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dp-terraform-github-repositories" })
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dp-terraform-github-repositories:*" })
   common_tags        = {}
   name               = "MgmtDPTerraformGitHubRepositoriesRole"
   policy_attachments = {
@@ -28,7 +28,7 @@ module "terraform_github_repository_iam" {
 module "terraform_github_repository_policy" {
   source        = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_policy"
   name          = "MgmtDPTerraformGitHubRepositoriesPolicy"
-  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name })
+  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name, dynamo_table_arn = module.terraform_dynamo.table_arn })
 }
 
 module "github_oidc_provider" {

--- a/root_data.tf
+++ b/root_data.tf
@@ -1,0 +1,1 @@
+data "aws_caller_identity" "current" {}

--- a/root_provider.tf
+++ b/root_provider.tf
@@ -1,0 +1,9 @@
+terraform {
+  backend "s3" {
+    bucket         = "mgmt-dp-bootstrap-terraform-state"
+    key            = "terraform.state"
+    region         = "eu-west-2"
+    encrypt        = true
+    dynamodb_table = "mgmt-dp-bootstrap-terraform-state-lock"
+  }
+}

--- a/templates/iam_policy/terraform_state_access.json.tpl
+++ b/templates/iam_policy/terraform_state_access.json.tpl
@@ -1,0 +1,17 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Action": [
+        "s3:GetObject",
+        "s3:ListBucket",
+        "s3:PutObject"
+      ],
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ]
+    }
+  ]
+}

--- a/templates/iam_policy/terraform_state_access.json.tpl
+++ b/templates/iam_policy/terraform_state_access.json.tpl
@@ -4,13 +4,16 @@
     {
       "Effect": "Allow",
       "Action": [
+        "dynamodb:GetItem",
+        "dynamodb:PutItem",
         "s3:GetObject",
         "s3:ListBucket",
         "s3:PutObject"
       ],
       "Resource": [
         "arn:aws:s3:::${bucket_name}",
-        "arn:aws:s3:::${bucket_name}/*"
+        "arn:aws:s3:::${bucket_name}/*",
+        "${dynamo_table_arn}"
       ]
     }
   ]

--- a/templates/iam_policy/terraform_state_access.json.tpl
+++ b/templates/iam_policy/terraform_state_access.json.tpl
@@ -4,6 +4,8 @@
     {
       "Effect": "Allow",
       "Action": [
+        "dynamodb:DescribeTable",
+        "dynamodb:DeleteItem",
         "dynamodb:GetItem",
         "dynamodb:PutItem",
         "s3:GetObject",

--- a/templates/iam_role/github_assume_role.json.tpl
+++ b/templates/iam_role/github_assume_role.json.tpl
@@ -1,0 +1,20 @@
+{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Federated": "arn:aws:iam::${account_id}:oidc-provider/token.actions.githubusercontent.com"
+      },
+      "Action": "sts:AssumeRoleWithWebIdentity",
+      "Condition": {
+        "StringEquals": {
+          "token.actions.githubusercontent.com:aud": "sts.amazonaws.com"
+        },
+        "StringLike": {
+          "token.actions.githubusercontent.com:sub": "repo:nationalarchives/${repo_filter}"
+        }
+      }
+    }
+  ]
+}

--- a/templates/s3/s3_secure_transport.json.tpl
+++ b/templates/s3/s3_secure_transport.json.tpl
@@ -1,0 +1,21 @@
+{
+  "Id": "secure-transport-${bucket_name}",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSSLRequestsOnly",
+      "Action": "s3:*",
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      },
+      "Principal": "*"
+    }
+  ]
+}

--- a/templates/s3/s3_secure_transport_logging.json.tpl
+++ b/templates/s3/s3_secure_transport_logging.json.tpl
@@ -1,0 +1,29 @@
+{
+  "Id": "secure-transport-and-logging",
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Sid": "AllowSSLRequestsOnly",
+      "Action": "s3:*",
+      "Effect": "Deny",
+      "Resource": [
+        "arn:aws:s3:::${bucket_name}",
+        "arn:aws:s3:::${bucket_name}/*"
+      ],
+      "Condition": {
+        "Bool": {
+          "aws:SecureTransport": "false"
+        }
+      },
+      "Principal": "*"
+    },
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "logging.s3.amazonaws.com"
+      },
+      "Action": "s3:PutObject",
+      "Resource": "arn:aws:s3:::${bucket_name}/*"
+    }
+  ]
+}


### PR DESCRIPTION
This repository is used to create resources needed by terraform for the
main project. So far there is:
* An S3 bucket for the state.
* A dynamo table for the state lock.

Other things will be added as we need them.

This is using the new da-terraform-modules repo for the modules which
isn't merged yet so the tests won't pass here until
https://github.com/nationalarchives/da-terraform-modules/pull/1 is
merged.
