### PR TITLE
Add new terraform deploy policy and add lock table.

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -33,10 +33,27 @@ module "terraform_github_repository_iam" {
   }
 }
 
+module "terraform_github_repository_da_iam" {
+  source             = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_role"
+  assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "da-*" })
+  common_tags        = {}
+  name               = "MgmtDATerraformGitHubRepositoriesRole"
+  policy_attachments = {
+    state_access_policy = module.terraform_da_github_repository_policy.policy_arn
+    ssm_policy          = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+  }
+}
+
 module "terraform_github_repository_policy" {
   source        = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_policy"
   name          = "MgmtDPTerraformGitHubRepositoriesPolicy"
-  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name, dynamo_table_arn = module.terraform_dynamo.table_arn, da_dynamo_table_arn = module.da_terraform_dynamo.table_arn })
+  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name, dynamo_table_arn = module.terraform_dynamo.table_arn })
+}
+
+module "terraform_da_github_repository_policy" {
+  source        = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_policy"
+  name          = "MgmtDATerraformGitHubRepositoriesPolicy"
+  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name, dynamo_table_arn = module.da_terraform_dynamo.table_arn })
 }
 
 module "github_oidc_provider" {

--- a/root.tf
+++ b/root.tf
@@ -15,6 +15,13 @@ module "terraform_dynamo" {
   table_name    = "mgmt-dp-terraform-state-lock"
 }
 
+module "da_terraform_dynamo" {
+  source        = "git::https://github.com/nationalarchives/da-terraform-modules.git//dynamo"
+  hash_key      = "LockID"
+  hash_key_type = "S"
+  table_name    = "mgmt-da-terraform-state-lock"
+}
+
 module "terraform_github_repository_iam" {
   source             = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_role"
   assume_role_policy = templatefile("${path.module}/templates/iam_role/github_assume_role.json.tpl", { account_id = data.aws_caller_identity.current.account_id, repo_filter = "dp-*" })
@@ -29,7 +36,7 @@ module "terraform_github_repository_iam" {
 module "terraform_github_repository_policy" {
   source        = "git::https://github.com/nationalarchives/tdr-terraform-modules.git//iam_policy"
   name          = "MgmtDPTerraformGitHubRepositoriesPolicy"
-  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name, dynamo_table_arn = module.terraform_dynamo.table_arn })
+  policy_string = templatefile("${path.module}/templates/iam_policy/terraform_state_access.json.tpl", { bucket_name = local.terraform_state_bucket_name, dynamo_table_arn = module.terraform_dynamo.table_arn, da_dynamo_table_arn = module.da_terraform_dynamo.table_arn })
 }
 
 module "github_oidc_provider" {

--- a/templates/iam_policy/terraform_state_access.json.tpl
+++ b/templates/iam_policy/terraform_state_access.json.tpl
@@ -15,8 +15,7 @@
       "Resource": [
         "arn:aws:s3:::${bucket_name}",
         "arn:aws:s3:::${bucket_name}/*",
-        "${dynamo_table_arn}",
-        "${da_dynamo_table_arn}"
+        "${dynamo_table_arn}"
       ]
     }
   ]

--- a/templates/iam_policy/terraform_state_access.json.tpl
+++ b/templates/iam_policy/terraform_state_access.json.tpl
@@ -15,7 +15,8 @@
       "Resource": [
         "arn:aws:s3:::${bucket_name}",
         "arn:aws:s3:::${bucket_name}/*",
-        "${dynamo_table_arn}"
+        "${dynamo_table_arn}",
+        "${da_dynamo_table_arn}"
       ]
     }
   ]


### PR DESCRIPTION
We're hosting the state file and the dynamo table for the da-terraform-github-repositories.
I've added the dynamo table and created a new role for deploying to the da-* repositories.
